### PR TITLE
Show real font rendering in generated comments

### DIFF
--- a/font_conv_core.php
+++ b/font_conv_core.php
@@ -409,12 +409,13 @@ function convert_letter($glyph, $unicode,  $w, $bpp) {
             $c = imagecolorat($glyph, $x + $x_start, $y);
             $c = $c & 0xFF;
             $act_byte |= $c >> (8 - $bpp);
+            $c = ($c >> (8 - $bpp)) << (8 - $bpp);
             
-            if($c > 192) {
+            if($c >= 192) {
                 $comment .= "@";
-            } else if($c > 128) {
+            } else if($c >= 128) {
                 $comment .= "%";
-            } else if($c > 64) {
+            } else if($c >= 64) {
                 $comment .= "+";
             } else {
                 $comment .= ".";


### PR DESCRIPTION
Comments in generated C file was always antialiassed which was confusing. Now, comments represent real font rendering and respect used bpp.