### PR TITLE
Bug fixes in image converter

### DIFF
--- a/img_conv_core.php
+++ b/img_conv_core.php
@@ -629,6 +629,7 @@ else{
   /*The scripts runs OFFLINE (likely in command)*/
   if(isset($_POST["name"])){
     $output_name = $_POST["name"];
+    echo("output_name:"."$output_name\n");
   }
   else{
     echo("Mising Name\n");
@@ -638,6 +639,7 @@ else{
   if(isset($_POST["img"])){
     $img_file = $_POST["img"];
     $img_file_name = $_POST["img"];
+    echo("img_file:"."$img_file\n");
   }
   else{
     echo("Mising image file\n");
@@ -646,20 +648,15 @@ else{
 
   if(isset($_POST["format"])){
     $format = $_POST["format"];
+    echo("format:"."$format\n");
   }
   else{
     $format = "c_array";
   }
 
-  if(isset($_POST["transp"])){
-    $transp = $_POST["transp"];
-  }
-  else{
-    $transp = "none";
-  }
-
   if(isset($_POST["dith"])){
     $dith = $_POST["dith"];
+    echo("dith:"."$dith\n");
   }
   else {
     $dith = "enabled";

--- a/img_conv_core.php
+++ b/img_conv_core.php
@@ -113,7 +113,7 @@ class Converter {
             imagetruecolortopalette($this->img, false, $palette_size);
            
 	        for($i = 0; $i < $palette_size; $i++) {
-               // TODO Warning when: format=indexed_8
+               // TODO !WARNING SUPPRESSED! Warning when: format=indexed_8
 	           @$c = imagecolorsforindex ($this->img , $i);
                array_push($this->d_out, $c['blue'], $c['green'], $c['red'], 0xFF); 
 	        }         
@@ -128,7 +128,7 @@ class Converter {
             }
         }
 
-        // TODO WARNING SUPRESSED
+        // TODO !WARNING SUPPRESSED!
         @imagecopy ($this->img, $img_tmp,  0 , 0 , 0 , 0 , $this->w , $this->h); 
     }
             
@@ -342,7 +342,7 @@ lv_img_dsc_t " . $this->out_name . " = {
     function download_bin($name, $cf = -1, $content = 0){
       global $offline;
       
-      // TODO WARNING SUPRESSED
+      // TODO !WARNING SUPPRESSED!
       if(@count($content) <= 1) {
         $content = $this->d_out;
       }
@@ -441,7 +441,8 @@ lv_img_dsc_t " . $this->out_name . " = {
             $w = $this->w >> 3;
             if($this->w & 0x07) $w++;
             $p = $w * $y + ($x >> 3);
-            $this->d_out[$p] &= ~(1 << (7 - ($x & 0x7)));       /*Clear the bits first*/
+            // TODO !WARNING SUPPRESSED! Warning when: format=alpha_1
+            @$this->d_out[$p] &= ~(1 << (7 - ($x & 0x7)));       /*Clear the bits first*/
             if($a > 0x80) {
                 $this->d_out[$p] |= 1 << (7 - ($x & 0x7));
             } 
@@ -451,7 +452,8 @@ lv_img_dsc_t " . $this->out_name . " = {
             if($this->w & 0x03) $w++;
             
             $p = $w * $y + ($x >> 2);
-            $this->d_out[$p] &= ~(0x3 << (6 - (($x & 0x3) * 2)));       /*Clear the bits first*/
+            // TODO !WARNING SUPPRESSED! Warning when: format=alpha_2
+            @$this->d_out[$p] &= ~(0x3 << (6 - (($x & 0x3) * 2)));       /*Clear the bits first*/
             $this->d_out[$p] |= ($a >> 6) << (6 - (($x & 0x3) * 2)); 
         }
         else if($this->cf == self::CF_ALPHA_4_BIT) {
@@ -459,7 +461,8 @@ lv_img_dsc_t " . $this->out_name . " = {
             if($this->w & 0x01) $w++;
             
             $p = $w * $y + ($x >> 1);
-            $this->d_out[$p] &= ~(0xF << (4 - (($x & 0x1) * 4)));       /*Clear the bits first*/
+            // TODO !WARNING SUPPRESSED! Warning when: format=alpha_4
+            @$this->d_out[$p] &= ~(0xF << (4 - (($x & 0x1) * 4)));       /*Clear the bits first*/
             $this->d_out[$p] |= ($a >> 4) << (4 - (($x & 0x1) * 4)); 
         }
         else if($this->cf == self::CF_ALPHA_8_BIT) {
@@ -471,7 +474,7 @@ lv_img_dsc_t " . $this->out_name . " = {
             if($this->w & 0x07) $w++;
             
             $p = $w * $y + ($x >> 3) + 8;                       /* +8 for the palette*/
-            // TODO Warning when: format=indexed_1
+            // TODO !WARNING SUPPRESSED! Warning when: format=indexed_1
             @$this->d_out[$p] &= ~(1 << (7 - ($x & 0x7)));       /*Clear the bits first*/
             $this->d_out[$p] |= ($c & 0x1) << (7 - ($x & 0x7)); 
             //echo($c . " ");
@@ -481,7 +484,7 @@ lv_img_dsc_t " . $this->out_name . " = {
             if($this->w & 0x03) $w++;
             
             $p = $w * $y + ($x >> 2) + 16;                              /* +16 for the palette*/
-            // TODO Warning when: format=indexed_2
+            // TODO !WARNING SUPPRESSED! Warning when: format=indexed_2
             @$this->d_out[$p] &= ~(0x3 << (6 - (($x & 0x3) * 2)));       /*Clear the bits first*/
             $this->d_out[$p] |= ($c & 0x3) << (6 - (($x & 0x3) * 2)); 
         }
@@ -490,7 +493,7 @@ lv_img_dsc_t " . $this->out_name . " = {
             if($this->w & 0x01) $w++;
             
             $p = $w * $y + ($x >> 1) + 64;                              /* +64 for the palette*/
-            // TODO Warning when: format=indexed_4
+            // TODO !WARNING SUPPRESSED! Warning when: format=indexed_4
             @$this->d_out[$p] &= ~(0xF << (4 - (($x & 0x1) * 4)));       /*Clear the bits first*/
             $this->d_out[$p] |= ($c & 0xF) << (4 - (($x & 0x1) * 4)); 
         }

--- a/img_conv_core.php
+++ b/img_conv_core.php
@@ -733,7 +733,7 @@ if(!strcmp($format, "c_array")) {
          $conv->download_c($conv->out_name);
     }
     else if(!strcmp($cf, "raw_alpha")) {
-         $conv->convert($conv::CF_RAW, 1);
+         $conv->convert($conv::CF_RAW_ALPHA, 1);
          $conv->download_c($conv->out_name);
     }
     else if(!strcmp($cf, "raw_chroma")) {


### PR DESCRIPTION
Hi,

I fixed some bugs in image converter. Unfortunately I haven't got enough time to resolve all problems and warnings, however I've marked all warnings that I detected in code.

### Fixes:
- The converter didn't work when running offline, because there were no $cf variable declared. I've added that.
- There were some wrong calls to class constants. Inside class they should be preceded by `self::`, outside class by `class_variable::`
- Some code remains from previous converter, some code was unnecessary.
- Because of no `$this->` inside dithering section, it do not work. Now it should!

All warnings was suppressed in order to detect all of them. They are marked with `// TODO`
