### PR TITLE
bbx shifting and ascii flag

### DIFF
--- a/bdf_font_converter.py
+++ b/bdf_font_converter.py
@@ -259,7 +259,7 @@ static const lv_font_glyph_dsc_t %s_glyph_dsc[] =
     #####################
     out.write(
 '''
-lv_font_t %s =
+lv_font_t lv_font_%s =
 {
     .unicode_first = %d,	/*First Unicode letter in this font*/
     .unicode_last = %d,	/*Last Unicode letter in this font*/

--- a/bdf_font_converter.py
+++ b/bdf_font_converter.py
@@ -201,10 +201,6 @@ def main():
         for glyph in glyphs:
             if( glyph.encoding <= 127 ):
                 ascii_glyphs.append(glyph)
-            '''
-            if( int(glyph.name[2:], 16) <= 127 ):
-                ascii_glyphs.append(glyph)
-            '''
         glyphs = ascii_glyphs
 
     glyphs = apply_bbx(glyphs)

--- a/bdf_font_converter.py
+++ b/bdf_font_converter.py
@@ -183,7 +183,7 @@ def parse_args():
     parser.add_argument('font_name', type=str, default='font_name',
             help='Name of the font to be generated')
     parser.add_argument('--toggle', '-t', action='store_true',
-            help='''Wrap entire file in "#if USE" macro''')
+            help='''Wrap entire file in "#if USE_LV_FONT_" macro''')
     parser.add_argument('--ascii', action='store_true',
             help='''Limit exported range to 0-127''')
     args = parser.parse_args()
@@ -215,7 +215,7 @@ def main():
 
     if args.toggle:
         out.write('''
-#if USE_%s != 0  /*Can be enabled in lv_conf.h*/
+#if USE_LV_FONT_%s != 0  /*Can be enabled in lv_conf.h*/
 ''' % args.font_name.upper())
 
     #################


### PR DESCRIPTION
Previously I wasn't shifting glyphs by the specified bbx parameter. This also enforces a constant glyph height. This makes the tool compatible with a lot more fonts for converting.

I also added a flag `--ascii` to only convert symbols below `127`.